### PR TITLE
add_dask_helper

### DIFF
--- a/Start_Dask_Cluster_Nebari.ipynb
+++ b/Start_Dask_Cluster_Nebari.ipynb
@@ -1,0 +1,96 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# nebari.esipfed.org Dask Cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The 'cluster' object can be used to adjust cluster behavior.  i.e. 'cluster.adapt(minimum=10)'\n",
+      "The 'client' object can be used to directly interact with the cluster.  i.e. 'client.submit(func)' \n",
+      "The link to view the client dashboard is:\n",
+      ">  https://nebari.esipfed.org/gateway/clusters/dev.d819eaadda7a452590fca3e69b8e8ef7/status\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import logging\n",
+    "\n",
+    "try:\n",
+    "    from dask_gateway import Gateway\n",
+    "except ImportError:\n",
+    "    logging.error(\"Unable to import Dask Gateway.  Are you running in a cloud compute environment?\\n\")\n",
+    "    raise\n",
+    "os.environ['DASK_DISTRIBUTED__SCHEDULER__WORKER_SATURATION'] = \"1.0\"\n",
+    "\n",
+    "gateway = Gateway()\n",
+    "_options = gateway.cluster_options()\n",
+    "_options.conda_environment='users/users-pangeo'  ##<< this is the conda environment we use on nebari.\n",
+    "_options.profile = 'Medium Worker'\n",
+    "_env_to_add={}\n",
+    "aws_env_vars=['AWS_ACCESS_KEY_ID',\n",
+    "              'AWS_SECRET_ACCESS_KEY',\n",
+    "              'AWS_SESSION_TOKEN',\n",
+    "              'AWS_DEFAULT_REGION',\n",
+    "              'AWS_S3_ENDPOINT']\n",
+    "for _e in aws_env_vars:\n",
+    "    if _e in os.environ:\n",
+    "        _env_to_add[_e] = os.environ[_e]\n",
+    "_options.environment_vars = _env_to_add    \n",
+    "cluster = gateway.new_cluster(_options)          ##<< create cluster via the dask gateway\n",
+    "cluster.adapt(minimum=2, maximum=30)             ##<< Sets scaling parameters. \n",
+    "\n",
+    "client = cluster.get_client()\n",
+    "\n",
+    "print(\"The 'cluster' object can be used to adjust cluster behavior.  i.e. 'cluster.adapt(minimum=10)'\")\n",
+    "print(\"The 'client' object can be used to directly interact with the cluster.  i.e. 'client.submit(func)' \")\n",
+    "print(f\"The link to view the client dashboard is:\\n>  {client.dashboard_link}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "gzt5142-gzt5142-pangeo-jbook",
+   "language": "python",
+   "name": "conda-env-gzt5142-gzt5142-pangeo-jbook-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.16"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d7ebce313f85fb1ac8949e834c83f371584cb2422d845bf1570c1220fdedc716"
+   }
+  },
+  "widgets": {
+   "application/vnd.jupyter.widget-state+json": {
+    "state": {},
+    "version_major": 2,
+    "version_minor": 0
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/hurricane_ike_water_levels.ipynb
+++ b/hurricane_ike_water_levels.ipynb
@@ -155,37 +155,11 @@
    },
    "outputs": [],
    "source": [
-    "from dask_gateway import Gateway\n",
-    "import os\n",
-    "# instantiate dask gateway\n",
-    "gateway = Gateway()\n",
-    "\n",
-    "# specify cluster options\n",
-    "options = gateway.cluster_options()\n",
-    "options.conda_environment='users/users-pangeo'\n",
-    "options.profile = 'Medium Worker'   # 2 threads/worker\n",
-    "\n",
-    "# set environment variables for cluster workers (including AWS credential environment variables)\n",
-    "options.environment_vars = dict(os.environ)\n",
-    "\n",
-    "# create new cluster\n",
-    "cluster = gateway.new_cluster(options)\n",
-    "\n",
-    "# get the client for the cluster\n",
-    "client = cluster.get_client()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "n_workers=30\n",
-    "cluster.scale(n_workers)"
+    "%run ./Start_Dask_Cluster_Nebari.ipynb\n",
+    "## If this notebook is not being run on Nebari/ESIP, replace the above \n",
+    "## path name with a helper appropriate to your compute environment.  Examples:\n",
+    "# %run ../environment_set_up/Start_Dask_Cluster_Denali.ipynb\n",
+    "# %run ../environment_set_up/Start_Dask_Cluster_Tallgrass.ipynb"
    ]
   },
   {


### PR DESCRIPTION
This PR add's the Nebari dask helper script and references it from the notebooks using a cluster. This will remove any reliance on having the environment_set_up folder copied into Nebari already, and make notebooks more consistent.